### PR TITLE
Bulk discount delete

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -17,5 +17,9 @@ class BulkDiscountsController < ApplicationController
         redirect_to merchant_bulk_discounts_path(params[:merchant_id])
     end
 
+    def destroy
+        BulkDiscount.find(params[:id]).destroy
+        redirect_to merchant_bulk_discounts_path(params[:merchant_id])
+    end
 
 end

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -3,8 +3,9 @@
 <div id="bulk-discount-list">
     <% @bulk_discounts.each do |bulk_discount| %>
         <div id="bulk-discount<%= bulk_discount.id %>">
-            <p>Discount Deal: <b><%= bulk_discount.discount %></b>% off at <b><%= bulk_discount.threshold_amount %></b> items! 
-            <%= link_to "View Discount Information",  "/merchants/#{@merchant.id}/bulk_discounts/#{bulk_discount.id}" %></p>
+            <p><b>Discount Deal: <%= bulk_discount.discount %>% off at <%= bulk_discount.threshold_amount %> items!</b> 
+            <b><%= link_to "View Discount Information",  "/merchants/#{@merchant.id}/bulk_discounts/#{bulk_discount.id}" %></b>
+            <b><%= link_to "Delete This Discount", "/merchants/#{@merchant.id}/bulk_discounts/#{bulk_discount.id}", method: :delete %></b></p>
         </div>
     <% end %>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # patch '/merchants/:id/'
 
   resources :merchants, only: %i[show update new] do
-    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create]
+    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create destroy]
     resources :invoices, controller: 'merchant_invoices', only: %i[index show update]
     resources :items, controller: 'merchant_items', only: %i[index edit show update new create]
   end

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -87,4 +87,44 @@ RSpec.describe 'bulk discounts index' do
         
         expect(current_path).to eq(new_merchant_bulk_discount_path(pokemart))
     end
+
+    it 'displays a link to delete a discount' do
+        pokemart = Merchant.create!(name: "PokeMart")
+        pokegarden = Merchant.create!(name: "PokeGarden")
+
+        pokemart_sale1 = BulkDiscount.create!(discount: 5, threshold_amount: 10, merchant: pokemart)
+        pokemart_sale2 = BulkDiscount.create!(discount: 10, threshold_amount: 15, merchant: pokemart)
+        pokemart_sale3 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+        pokegarden_sale1 = BulkDiscount.create!(discount: 15, threshold_amount: 10, merchant: pokegarden)
+        pokegarden_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 20, merchant: pokegarden)
+        pokegarden_sale3 = BulkDiscount.create!(discount: 30, threshold_amount: 25, merchant: pokegarden)
+
+        visit merchant_bulk_discounts_path(pokemart.id)
+
+        within "#bulk-discount#{pokemart_sale1.id}" do
+            expect(page).to have_content("5% off at 10 items!")
+            expect(page).to have_link("Delete This Discount")
+        end
+
+        within "#bulk-discount#{pokemart_sale2.id}" do
+            expect(page).to have_content("10% off at 15 items!")
+            expect(page).to have_link("Delete This Discount")
+            click_on "Delete This Discount"           
+        end
+        
+        within "#bulk-discount#{pokemart_sale3.id}" do
+            expect(page).to have_content("15% off at 20 items!")
+            expect(page).to have_link("Delete This Discount")
+            click_on "Delete This Discount"          
+        end
+
+        expect(current_path).to eq(merchant_bulk_discounts_path(pokemart.id))
+
+        within "#bulk-discount-list" do
+            expect(page).to have_content("5% off at 10 items!")
+            expect(page).to_not have_content("10% off at 15 items!")
+            expect(page).to_not have_content("15% off at 20 items!")
+        end
+
+    end
 end


### PR DESCRIPTION
Resolves #4 Merchant Bulk Discount Delete:

- Add Test and Feature: Displays a link to delete a discount
- Add Feature: Bulk discount destroy route
- Add Feature: Bulk discount controller with destroy


```
Merchant Bulk Discount Delete

As a merchant
When I visit my bulk discounts index
Then next to each bulk discount I see a link to delete it
When I click this link
Then I am redirected back to the bulk discounts index page
And I no longer see the discount listed
```