### PR TITLE
Bulk discount show

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -5,7 +5,7 @@ class BulkDiscountsController < ApplicationController
     end
 
     def show
-
+        @bulk_discount = BulkDiscount.find(params[:id])
     end
 
     def new

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -1,1 +1,6 @@
-<h1> Bulk Discount Show Page </h1>
+<h1> Bulk Discount '<%= @bulk_discount.discount %>% off at <%= @bulk_discount.threshold_amount %> items' Show Page </h1>
+
+<div id="discount-details">
+    <p>Discount Percent: <%= @bulk_discount.discount %>%</p>
+    <p>Item Amount Required: <%= @bulk_discount.threshold_amount %> items</p>
+</div>

--- a/spec/features/merchants/bulk_discounts/show_spec.rb
+++ b/spec/features/merchants/bulk_discounts/show_spec.rb
@@ -1,0 +1,25 @@
+require 'rails_helper'
+
+RSpec.describe 'bulk discounts show' do
+    it 'displays discount percent and threshold amount' do
+        pokemart = Merchant.create!(name: "PokeMart")
+        pokegarden = Merchant.create!(name: "PokeGarden")
+
+        pokemart_sale1 = BulkDiscount.create!(discount: 5, threshold_amount: 10, merchant: pokemart)
+        pokemart_sale2 = BulkDiscount.create!(discount: 10, threshold_amount: 15, merchant: pokemart)
+        pokemart_sale3 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+        pokegarden_sale1 = BulkDiscount.create!(discount: 15, threshold_amount: 10, merchant: pokegarden)
+        pokegarden_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 20, merchant: pokegarden)
+        pokegarden_sale3 = BulkDiscount.create!(discount: 30, threshold_amount: 25, merchant: pokegarden)
+
+        visit "/merchants/#{pokemart.id}/bulk_discounts/#{pokemart_sale1.id}"
+        
+        within "#discount-details" do
+            expect(page).to have_content('Discount Percent: 5%')
+            expect(page).to have_content('Item Amount Required: 10 items')
+            expect(page).to_not have_content('Discount Percent: 10%')
+            expect(page).to_not have_content('Item Amount Required: 15 items')
+        end
+    end
+end
+


### PR DESCRIPTION
Resolves #5 Merchant Bulk Discount Show:

- Add Test: displays discount percent and threshold amount
- Add Feature: displays discount percent and threshold amount
- Add Feature: bulk discount controller with show functionality

```
Merchant Bulk Discount Show

As a merchant
When I visit my bulk discount show page
Then I see the bulk discount's quantity threshold and percentage discount
```