### PR TITLE
Bulk discount edit

### DIFF
--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -17,9 +17,24 @@ class BulkDiscountsController < ApplicationController
         redirect_to merchant_bulk_discounts_path(params[:merchant_id])
     end
 
+    def edit
+        @bulk_discount = BulkDiscount.find(params[:id])
+    end
+
+    def update
+        @bulk_discount = BulkDiscount.find(params[:id])
+        @bulk_discount.update(discount: bulk_discount_params[:discount], threshold_amount: bulk_discount_params[:threshold_amount])
+        redirect_to merchant_bulk_discount_path(@bulk_discount.merchant,@bulk_discount)
+    end
+
     def destroy
         BulkDiscount.find(params[:id]).destroy
         redirect_to merchant_bulk_discounts_path(params[:merchant_id])
     end
 
+    private
+    
+    def bulk_discount_params
+        params.permit(:merchant_id, :discount, :threshold_amount)
+    end
 end

--- a/app/views/bulk_discounts/edit.html.erb
+++ b/app/views/bulk_discounts/edit.html.erb
@@ -1,0 +1,9 @@
+<h1> Edit Bulk Discount Page </h1>
+
+<div id="discount-edit-form">
+    <%= form_with url: merchant_bulk_discount_path(@bulk_discount.id), method: :patch, local: true do |f| %>
+        <p><%= f.label :discount, "Discount Percent: " %><%= f.number_field :discount, value: @bulk_discount.discount %></p>
+        <p><%= f.label :threshold_amount, "Item Amount Required: " %><%= f.number_field :threshold_amount, value: @bulk_discount.threshold_amount %></p>
+        <p><%= f.submit " Submit " %></p>
+    <% end %>
+</div>

--- a/app/views/bulk_discounts/show.html.erb
+++ b/app/views/bulk_discounts/show.html.erb
@@ -3,4 +3,5 @@
 <div id="discount-details">
     <p>Discount Percent: <%= @bulk_discount.discount %>%</p>
     <p>Item Amount Required: <%= @bulk_discount.threshold_amount %> items</p>
+    <h3><%= link_to "Edit Discount", edit_merchant_bulk_discount_path(@bulk_discount.merchant,@bulk_discount) %></h3>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Rails.application.routes.draw do
   # patch '/merchants/:id/'
 
   resources :merchants, only: %i[show update new] do
-    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create destroy]
+    resources :bulk_discounts, controller: 'bulk_discounts', only: %i[index show new create edit update destroy]
     resources :invoices, controller: 'merchant_invoices', only: %i[index show update]
     resources :items, controller: 'merchant_items', only: %i[index edit show update new create]
   end

--- a/spec/features/merchants/bulk_discounts/edit_spec.rb
+++ b/spec/features/merchants/bulk_discounts/edit_spec.rb
@@ -1,0 +1,32 @@
+require 'rails_helper'
+
+RSpec.describe 'bulk discounts edit' do
+    it 'displays form to edit the discount' do
+
+        pokemart = Merchant.create!(name: "PokeMart")
+        pokegarden = Merchant.create!(name: "PokeGarden")
+
+        pokemart_sale1 = BulkDiscount.create!(discount: 5, threshold_amount: 10, merchant: pokemart)
+        pokemart_sale2 = BulkDiscount.create!(discount: 10, threshold_amount: 15, merchant: pokemart)
+        pokemart_sale3 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+        pokegarden_sale1 = BulkDiscount.create!(discount: 15, threshold_amount: 10, merchant: pokegarden)
+        pokegarden_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 20, merchant: pokegarden)
+        pokegarden_sale3 = BulkDiscount.create!(discount: 30, threshold_amount: 25, merchant: pokegarden)
+
+        visit edit_merchant_bulk_discount_path(pokemart_sale1.merchant,pokemart_sale1)
+        
+        within "#discount-edit-form" do
+            expect(page).to have_field("Discount Percent", with: 5)
+            expect(page).to have_field("Item Amount Required", with: 10)
+            
+            fill_in "Discount Percent", with: 4
+            fill_in "Item Amount Required", with: 11
+            
+            click_on "Submit"
+        end
+        
+        expect(current_path).to eq("/merchants/#{pokemart.id}/bulk_discounts/#{pokemart_sale1.id}")
+        expect(page).to have_content('Discount Percent: 4%')
+        expect(page).to have_content('Item Amount Required: 11 items')
+    end
+end

--- a/spec/features/merchants/bulk_discounts/show_spec.rb
+++ b/spec/features/merchants/bulk_discounts/show_spec.rb
@@ -21,5 +21,27 @@ RSpec.describe 'bulk discounts show' do
             expect(page).to_not have_content('Item Amount Required: 15 items')
         end
     end
-end
 
+    it 'displays link to edit the discount' do
+        pokemart = Merchant.create!(name: "PokeMart")
+        pokegarden = Merchant.create!(name: "PokeGarden")
+
+        pokemart_sale1 = BulkDiscount.create!(discount: 5, threshold_amount: 10, merchant: pokemart)
+        pokemart_sale2 = BulkDiscount.create!(discount: 10, threshold_amount: 15, merchant: pokemart)
+        pokemart_sale3 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+        pokegarden_sale1 = BulkDiscount.create!(discount: 15, threshold_amount: 10, merchant: pokegarden)
+        pokegarden_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 20, merchant: pokegarden)
+        pokegarden_sale3 = BulkDiscount.create!(discount: 30, threshold_amount: 25, merchant: pokegarden)
+
+        visit "/merchants/#{pokemart.id}/bulk_discounts/#{pokemart_sale1.id}"
+        
+        within "#discount-details" do
+            expect(page).to have_content('Discount Percent: 5%')
+            expect(page).to have_content('Item Amount Required: 10 items')
+
+            click_link "Edit Discount"
+        end
+
+        expect(current_path).to eq(edit_merchant_bulk_discount_path(pokemart_sale1.merchant,pokemart_sale1))
+    end
+end


### PR DESCRIPTION
Resolves #6 Merchant Bulk Discount Edit:

- Add Test and Feature: display link to edit discount
- Add Test and Feature: display form to edit discount
- Add Feature: bulk discounts controller with edit and update functionality
- Add Featire: bulk discount route to edit and update

Complete the Following User Story:
```
Merchant Bulk Discount Edit

As a merchant
When I visit my bulk discount show page
Then I see a link to edit the bulk discount
When I click this link
Then I am taken to a new page with a form to edit the discount
And I see that the discounts current attributes are pre-poluated in the form
When I change any/all of the information and click submit
Then I am redirected to the bulk discount's show page
And I see that the discount's attributes have been updated
```