### PR TITLE
Bulk discount revenue

### DIFF
--- a/app/models/bulk_discount.rb
+++ b/app/models/bulk_discount.rb
@@ -1,3 +1,6 @@
 class BulkDiscount < ApplicationRecord
     belongs_to :merchant
+    has_many :items, through: :merchant
+    has_many :invoices, through: :merchant
+    has_many :invoice_items, through: :items
 end

--- a/app/models/customer.rb
+++ b/app/models/customer.rb
@@ -3,6 +3,7 @@ class Customer < ApplicationRecord
   validates :last_name, presence: true
 
   has_many :invoices
+  has_many :merchants, through: :invoices
   has_many :transactions, through: :invoices
 
   # Top 5 customers by transaction count

--- a/app/models/invoice_item.rb
+++ b/app/models/invoice_item.rb
@@ -3,8 +3,12 @@ class InvoiceItem < ApplicationRecord
 
   belongs_to :invoice
   belongs_to :item
+  has_one :merchant, through: :item
+  has_many :bulk_discounts, through: :merchant
 
   def total_revenue
     quantity * unit_price
   end
+
+  
 end

--- a/app/models/item.rb
+++ b/app/models/item.rb
@@ -5,6 +5,8 @@ class Item < ApplicationRecord
   has_many :invoice_items
   has_many :invoices, through: :invoice_items
   has_many :transactions, through: :invoices
+  has_many :customers, through: :invoices
+  has_many :bulk_discounts, through: :merchant
 
   def best_date
     self.invoices

--- a/app/views/merchant_invoices/show.html.erb
+++ b/app/views/merchant_invoices/show.html.erb
@@ -8,7 +8,7 @@
 </div>
 
 <div id="invoice-item-information">
-    <%= @invoice.invoice_items.each do |invoice_item|%>
+    <% @invoice.invoice_items.each do |invoice_item|%>
         <h3><%="Item Name: #{invoice_item.item.name}"%></h3>
         <p><%="Quantity Ordered: #{invoice_item.quantity}"%></p>
         <p><%="Price: #{number_to_currency(invoice_item.unit_price)}"%></p>
@@ -24,6 +24,10 @@
 </div>
 
 <div id="invoice-item-total-revenue">
-   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p><br>
+   <p>Total Revenue: <%= number_to_currency(@invoice.total_revenue) %></p>
+</div>
+
+<div id="invoice-item-discounted-revenue">
+   <p>Total Discounted Revenue: <%= number_to_currency(@invoice.total_discount_revenue) %></p><br>
 </div>
 

--- a/spec/features/merchants/invoices/show_spec.rb
+++ b/spec/features/merchants/invoices/show_spec.rb
@@ -108,4 +108,33 @@ RSpec.describe 'merchant_invoices show page' do
         expect(page).to have_content("shipped")
       end
   end
+
+  it 'displays total revenue and discounted revenue' do
+      pokemart = Merchant.create!(name: "PokeMart")
+
+      red = Customer.create!(first_name: 'Red', last_name: 'Trainer')
+      item1 = pokemart.items.create!(name: 'Phoenix Feather Wand', description: 'Ergonomic grip', unit_price: 30)
+      item2 = pokemart.items.create!(name: 'Harmonica', description: 'Makes pretty noise', unit_price: 20)
+      item3 = pokemart.items.create!(name: 'Bag of Holding', description: 'This bag has an interior space considerably larger than its outside dimensions, roughly 2 feet in diameter at the mouth and 4 feet deep.', unit_price: 10)
+
+      invoice1 = red.invoices.create!(status: 1)
+
+      invoice_item1 = InvoiceItem.create!(invoice: invoice1, item: item1, quantity: 10, unit_price: 30, status: 1)
+      invoice_item2 = InvoiceItem.create!(invoice: invoice1, item: item2, quantity: 21, unit_price: 20, status: 1)
+      invoice_item3 = InvoiceItem.create!(invoice: invoice1, item: item3, quantity: 5, unit_price: 10, status: 1)
+
+      pokemart_sale1 = BulkDiscount.create!(discount: 10, threshold_amount: 10, merchant: pokemart)
+      pokemart_sale2 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+      pokemart_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 30, merchant: pokemart)
+
+      visit merchant_invoice_path(pokemart.id, invoice1.id)
+
+      within "#invoice-item-total-revenue" do
+        expect(page).to have_content("Total Revenue: $770.0")
+      end
+
+      within "#invoice-item-discounted-revenue" do
+        expect(page).to have_content("Total Discounted Revenue: $677.0") # 30 dollars off item 1 + 63 dollars off item 2 = $93 discount off 770
+      end
+  end
 end

--- a/spec/models/bulk_discount_spec.rb
+++ b/spec/models/bulk_discount_spec.rb
@@ -3,5 +3,8 @@ require 'rails_helper'
 RSpec.describe BulkDiscount do
   describe 'relationships' do
     it { should belong_to :merchant }
+    it { should have_many(:items).through(:merchant)}
+    it { should have_many(:invoice_items).through(:items)}
+    it { should have_many(:invoices).through(:merchant)}
   end
 end

--- a/spec/models/invoice_item_spec.rb
+++ b/spec/models/invoice_item_spec.rb
@@ -4,7 +4,10 @@ RSpec.describe InvoiceItem do
   describe 'relationships' do
     it { should belong_to :invoice }
     it { should belong_to :item }
+    it { should have_one(:merchant).through(:item) }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
+
   describe 'instance methods' do
 
     it 'returns total_revenue' do

--- a/spec/models/item_spec.rb
+++ b/spec/models/item_spec.rb
@@ -6,6 +6,8 @@ RSpec.describe Item do
     it { should have_many :invoice_items }
     it { should have_many(:invoices).through(:invoice_items) }
     it { should have_many(:transactions).through(:invoices) }
+    it { should have_many(:customers).through(:invoices) }
+    it { should have_many(:bulk_discounts).through(:merchant) }
   end
 
   describe 'methods' do

--- a/spec/models/merchant_spec.rb
+++ b/spec/models/merchant_spec.rb
@@ -4,6 +4,10 @@ RSpec.describe Merchant do
   describe 'relationships' do
     it { should have_many :items }
     it { should have_many :bulk_discounts }
+    it { should have_many(:invoice_items).through(:items) }
+    it { should have_many(:invoices).through(:invoice_items) }
+    it { should have_many(:transactions).through(:invoices) }
+    it { should have_many(:customers).through(:invoices) }
   end
 
   describe 'instance methods' do


### PR DESCRIPTION
Resolves #7 Merchant Invoice Show Page: Total Revenue and Discounted Revenue:

-Add Test/Feature: Display total revenue and discounted revenue
-Add Test/Feature: Invoice model methods #discount_amount and #total_discount_revenue

Complete the Following User Story:
```
Merchant Invoice Show Page: Total Revenue and Discounted Revenue

As a merchant
When I visit my merchant invoice show page
Then I see the total revenue for my merchant from this invoice (not including discounts)
And I see the total discounted revenue for my merchant from this invoice which includes bulk discounts in the calculation
```