### PR TITLE
Holiday api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -35,6 +35,7 @@ gem 'jbuilder', '~> 2.5'
 
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'httparty'
 
 group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -78,6 +78,9 @@ GEM
     ffi (1.15.5-x86-mingw32)
     globalid (1.0.0)
       activesupport (>= 5.0)
+    httparty (0.20.0)
+      mime-types (~> 3.0)
+      multi_xml (>= 0.5.2)
     i18n (1.12.0)
       concurrent-ruby (~> 1.0)
     jbuilder (2.11.5)
@@ -97,11 +100,15 @@ GEM
     marcel (1.0.2)
     matrix (0.4.2)
     method_source (1.0.0)
+    mime-types (3.4.1)
+      mime-types-data (~> 3.2015)
+    mime-types-data (3.2022.0105)
     mini_mime (1.1.2)
     mini_portile2 (2.8.0)
     minitest (5.16.2)
     msgpack (1.5.4)
     msgpack (1.5.4-java)
+    multi_xml (0.6.0)
     nio4r (2.5.8)
     nio4r (2.5.8-java)
     nokogiri (1.13.8)
@@ -254,6 +261,7 @@ DEPENDENCIES
   bootsnap (>= 1.1.0)
   capybara
   coffee-rails (~> 4.2)
+  httparty
   jbuilder (~> 2.5)
   launchy
   listen (>= 3.0.5, < 3.2)

--- a/app/controllers/bulk_discounts_controller.rb
+++ b/app/controllers/bulk_discounts_controller.rb
@@ -1,7 +1,9 @@
+require './lib/holiday_calendar_search'
 class BulkDiscountsController < ApplicationController
     def index
         @merchant = Merchant.find(params[:merchant_id])
         @bulk_discounts = @merchant.bulk_discounts
+        @holiday_calendar_search = HolidayCalendarSearch.new
     end
 
     def show

--- a/app/views/bulk_discounts/index.html.erb
+++ b/app/views/bulk_discounts/index.html.erb
@@ -13,3 +13,9 @@
 <div id="create-bulk-discount">
     <h3><%= link_to "Create a New Bulk Discount", new_merchant_bulk_discount_path(@merchant) %></h3>
 </div>
+
+<div id="holidays-upcoming"><h3>Upcoming Holidays</h3>
+        <% @holiday_calendar_search.holiday_info.each do |date| %>
+            <p><%= date[:name] %> on <%= date[:date] %></p>
+        <% end %>
+</div>

--- a/lib/holiday_calendar_search.rb
+++ b/lib/holiday_calendar_search.rb
@@ -1,0 +1,12 @@
+require './lib/holiday_service'
+
+class HolidayCalendarSearch
+
+    def holiday_info
+        service.api_endpoint.first(3).map
+    end
+
+    def service
+        HolidayService.new
+    end
+end

--- a/lib/holiday_service.rb
+++ b/lib/holiday_service.rb
@@ -1,0 +1,95 @@
+require 'httparty'
+
+class HolidayService
+
+    def api_endpoint
+        get_url("https://date.nager.at/api/v3/NextPublicHolidays/US")
+    end
+
+    def get_url(url)
+        response = HTTParty.get(url)
+        JSON.parse(response.body, symbolize_names: true)
+    end
+end
+
+
+# #
+# Code	Details
+# 200	
+# Response body
+# Download
+# [
+#   {
+#     "date": "2022-09-05",
+#     "localName": "Labor Day",
+#     "name": "Labour Day",
+#     "countryCode": "US",
+#     "fixed": false,
+#     "global": true,
+#     "counties": null,
+#     "launchYear": null,
+#     "types": [
+#       "Public"
+#     ]
+#   },
+#   {
+#     "date": "2022-10-10",
+#     "localName": "Columbus Day",
+#     "name": "Columbus Day",
+#     "countryCode": "US",
+#     "fixed": false,
+#     "global": false,
+#     "counties": [
+#       "US-AL",
+#       "US-AZ",
+#       "US-CO",
+#       "US-CT",
+#       "US-DC",
+#       "US-GA",
+#       "US-ID",
+#       "US-IL",
+#       "US-IN",
+#       "US-IA",
+#       "US-KS",
+#       "US-KY",
+#       "US-LA",
+#       "US-ME",
+#       "US-MD",
+#       "US-MA",
+#       "US-MS",
+#       "US-MO",
+#       "US-MT",
+#       "US-NE",
+#       "US-NH",
+#       "US-NJ",
+#       "US-NM",
+#       "US-NY",
+#       "US-NC",
+#       "US-OH",
+#       "US-OK",
+#       "US-PA",
+#       "US-RI",
+#       "US-SC",
+#       "US-TN",
+#       "US-UT",
+#       "US-VA",
+#       "US-WV"
+#     ],
+#     "launchYear": null,
+#     "types": [
+#       "Public"
+#     ]
+#   },
+#   {
+#     "date": "2022-11-11",
+#     "localName": "Veterans Day",
+#     "name": "Veterans Day",
+#     "countryCode": "US",
+#     "fixed": false,
+#     "global": true,
+#     "counties": null,
+#     "launchYear": null,
+#     "types": [
+#       "Public"
+#     ]
+#   },

--- a/spec/features/merchants/bulk_discounts/index_spec.rb
+++ b/spec/features/merchants/bulk_discounts/index_spec.rb
@@ -125,6 +125,25 @@ RSpec.describe 'bulk discounts index' do
             expect(page).to_not have_content("10% off at 15 items!")
             expect(page).to_not have_content("15% off at 20 items!")
         end
+    end
 
+    it 'displays 3 upcoming holidays from api with httparty' do
+        pokemart = Merchant.create!(name: "PokeMart")
+        pokegarden = Merchant.create!(name: "PokeGarden")
+
+        pokemart_sale1 = BulkDiscount.create!(discount: 5, threshold_amount: 10, merchant: pokemart)
+        pokemart_sale2 = BulkDiscount.create!(discount: 10, threshold_amount: 15, merchant: pokemart)
+        pokemart_sale3 = BulkDiscount.create!(discount: 15, threshold_amount: 20, merchant: pokemart)
+        pokegarden_sale1 = BulkDiscount.create!(discount: 15, threshold_amount: 10, merchant: pokegarden)
+        pokegarden_sale2 = BulkDiscount.create!(discount: 25, threshold_amount: 20, merchant: pokegarden)
+        pokegarden_sale3 = BulkDiscount.create!(discount: 30, threshold_amount: 25, merchant: pokegarden)
+
+        visit merchant_bulk_discounts_path(pokemart.id)
+
+        within "#holidays-upcoming" do
+            expect(page).to have_content('Labour Day')
+            expect(page).to have_content('Columbus Day')
+            expect(page).to have_content('Veterans Day')
+        end
     end
 end


### PR DESCRIPTION
Resolves #10 Bulk Discounts Index: Upcoming Holidays:

- Add Test/Feature: displays 3 upcoming holidays from api with httparty
- Add Httparty gem
- Add Feature: Holiday api endpoint

Complete the Following User Story:
```
Bulk Discounts Index: Upcoming Holidays

As a merchant
When I visit the discounts index page
I see a section with a header of "Upcoming Holidays"
In this section the name and date of the next 3 upcoming US holidays are listed.

Use the Next Public Holidays Endpoint in the [Nager.Date API](https://date.nager.at/swagger/index.html)
```